### PR TITLE
Add CloudAMQP to list of cloud services

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ A list of open source message queue middlewares and MQ cloud services
 | Provider  | Product                                                                                             | Middlewares/Services               |
 |-----------|-----------------------------------------------------------------------------------------------------|------------------------------------|
 | Amazon    | [Amazon MQ](https://aws.amazon.com/amazon-mq/)                                                      | ActiveMQ,RabbitMQ,SQS(HTTP)        |
+| CloudAMQP | [CloudAMQP](https://www.cloudamqp.com/)                                                             | LavinMQ, RabbitMQ                  |
 | IBM       | [IBM MQ](https://www.ibm.com/products/mq), [Advanced](https://www.ibm.com/products/mq/advanced)     | IBM MQ                             |
 | Iron      | [Iron MQ](https://www.iron.io/mq)                                                                   | AWS Lambda, Amazon SQS             |
 | Red Hat   | [Red Hat AMQ](https://www.redhat.com/zh/technologies/jboss-middleware/amq)                          | ActiveMQ Artemis                   |


### PR DESCRIPTION
CloudAMQP has been providing hosted AMQP brokers since 2012: https://www.cloudamqp.com/changelog.html